### PR TITLE
impl: Implemetation crawling half-year report

### DIFF
--- a/crawling_dh.py
+++ b/crawling_dh.py
@@ -1,0 +1,48 @@
+import json
+import time
+from typing import Tuple
+
+import pandas as pd
+import requests
+from tqdm import tqdm
+
+from dh_utils.constant_dh import OG_URL, SRC_URL
+from dh_utils.utils_dh import check_count, del_blank, find_dcmNo, text_from_url
+
+
+def main(rcpno: str, cnt: int) -> Tuple[dict, int]:
+    res = {}
+    og = OG_URL.format(rcpno=rcpno)
+    start = time.time()
+    req = requests.get(og).text
+    cnt, start = check_count(cnt, start)
+    change = req.find("정 정 신 고")
+    dcmNo = find_dcmNo(req)
+    if change == -1:
+        id = [4, 10]
+    else:
+        id = [6, 12]
+    for i in id:
+        src = SRC_URL.format(rcpno=rcpno, dcmNo=dcmNo, id=i)
+        text = text_from_url(src)
+        cnt, start = check_count(cnt, start)
+        text = del_blank(text)
+        if i == id[0]:
+            res["회사의 개요"] = text
+        else:
+            res["사업의 개요"] = text
+
+    return (res, cnt)
+
+
+if __name__ == "__main__":
+    df = pd.read_csv("./반기보고서_코드.csv")
+    stock_rcpno = df.to_dict("records")
+    result = {}
+    cnt = 0
+    for dic in tqdm(stock_rcpno):
+        rcpno = dic["rcept_no"]
+        res, cnt = main(rcpno, cnt)
+        result[str(dic["stock_code"])] = res
+    with open("./result.json", "w") as f:
+        json.dump(result, f, ensure_ascii=False, indent=4)

--- a/dh_utils/constant_dh.py
+++ b/dh_utils/constant_dh.py
@@ -1,0 +1,6 @@
+RCPNO_REGEX: str = r'''node[0-9]\['rcpNo'\]\s*=\s*"[0-9]*"'''
+DCMNO_REGEX: str = r'''node[0-9]\['dcmNo'\]\s*=\s*"[0-9]*"'''
+ELEID_REGEX: str = r'''node[0-9]\['eleId'\]\s*=\s*"[0-9]*"'''
+
+OG_URL = "https://dart.fss.or.kr/dsaf001/main.do?rcpNo={rcpno}"
+SRC_URL = "https://dart.fss.or.kr/report/viewer.do?rcpNo={rcpno}&dcmNo={dcmNo}&eleId={id}&offset=800&length=4053&dtd=dart3.xsd"

--- a/dh_utils/utils_dh.py
+++ b/dh_utils/utils_dh.py
@@ -1,0 +1,54 @@
+import re
+import time
+from typing import Tuple
+
+import requests
+from bs4 import BeautifulSoup as bs
+
+from dh_utils.constant_dh import DCMNO_REGEX, ELEID_REGEX, RCPNO_REGEX
+
+
+def find_rcpNo(text: str) -> int:
+    rcpNo = re.findall(RCPNO_REGEX, text)
+    num = re.findall(r"[0-9]+", str(rcpNo[0]))[-1]
+    return int(num)
+
+
+def find_dcmNo(text: str) -> int:
+    dcmNo = re.findall(DCMNO_REGEX, text)
+    num = re.findall(r"[0-9]+", str(dcmNo[0]))[-1]
+    return int(num)
+
+
+def find_max_eleid(text: str) -> int:
+    id_ls = re.findall(ELEID_REGEX, text)
+    max_id = re.findall(r"[0-9]+", str(id_ls[-1]))
+    return int(max_id[-1])
+
+
+def del_blank(text: str) -> str:
+    text = re.sub("\s{2,}", " ", text)
+    text = re.sub("\n", " ", text)
+    return text.strip()
+
+
+def text_from_url(url: str) -> str:
+    req = requests.get(url).text
+    soup = bs(req, "lxml")
+    try:
+        text = soup.select("body")[0].get_text()
+    except IndexError:
+        text = ""
+    return text
+
+
+def check_count(cnt: int, start: float) -> Tuple[int, float]:
+    if cnt == 99:
+        diff = time.time() - start
+        if diff < 60:
+            time.sleep(round(60 - diff) + 1)
+            cnt = 0
+            start = time.time()
+    else:
+        cnt += 1
+    return (cnt, start)


### PR DESCRIPTION
## Description
- 분당 100개 제한을 피하기 위해서 접속횟수를 카운트 하여 100이 채워지면 소요시간을 1분에서 뺀 나머지 시간을 슬립하는 방식으로 크롤링을 진행
- 추가적으로 상수나 필요한 함수들은 따로 파일을 생성하여서 관리
- Langchain을 사용한 크롤링과 일반적인 크롤링을 비교한 결과 일반적인 크롤링이 50페이지 기준 약 3초가량 빠른 성능을 보여주어 일반적인 크롤링 사용


## What type of PR is this? (check all applicable)
- [x] 🔨 Implement
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🔥 Performance Improvements
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] ✅ Test
- [ ] ⏩ Revert


## Related issues, tickets and documents
<!-- delete comment and fill the empty spaces in the right column like below
Issue: resolve #1
-->
Issue: 


## [optional] Is there any comment for reviewers?


## [optional] Screenshots/Recordings


## [optional] Are there any post-deployment tasks we need to perform?

